### PR TITLE
fix styles for cross console

### DIFF
--- a/packages/integration-core/styles/core.css
+++ b/packages/integration-core/styles/core.css
@@ -2,54 +2,103 @@
     height: 100vh;
   }
   
+.pf-c-page__header {
+  grid-template-columns: auto auto !important;
+}
+
+.app-context-selector-wrapper {
+  height: 100%;
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.pf-c-page__header-tools {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.pf-c-context-selector {
+  height: 100%;
+  width: 100%;
+}
+
+.pf-c-context-selector__toggle {
+  height: 100%;
+  width: 100%;
+  background-color: var(--pf-global--BackgroundColor--dark-200);
+}
+
+.pf-c-context-selector__toggle::before {
+  border-top-color: var(--pf-global--BorderColor--200) !important;
+  border-right-color: var(--pf-global--BorderColor--200) !important;
+  border-bottom-color: var(--pf-global--BorderColor--200) !important;
+  border-left-color: var(--pf-global--BorderColor--200) !important;
+}
+
+.pf-c-context-selector__toggle::before {
+  border-bottom-width: 0px !important;
+}
+
+.pf-m-expanded.pf-c-context-selector__toggle::before,
+.pf-c-context-selector__toggle:hover::before,
+.pf-c-context-selector__toggle:focus::before {
+  border-top-color: var(--pf-global--active-color--100) !important;
+  border-top-width: var(--pf-global--BorderWidth--lg);
+}
+
+@media screen and (min-width: 576px) {
   .pf-c-page__header {
-    grid-template-columns: auto 1fr 1fr;
+    grid-template-columns: minmax(80px, 200px) auto auto !important;
   }
-  
+
   .app-context-selector-wrapper {
-    height: 100%;
-    grid-column: 1 / -1;
-    grid-row: 2 / 3;
+    grid-column: 2;
+    grid-row: 1;
   }
-  
+
   .pf-c-context-selector {
-    height: 100%;
-    width: 100%;
+    width: initial;
   }
-  
-   .pf-c-context-selector__toggle {
-    height: 100%;
-    width: 100%;
-    background-color: var(--pf-global--BackgroundColor--dark-200);
+
+  .pf-c-context-selector__toggle {
+    width: initial;
+    background-color: transparent;
   }
-  
+
   .pf-c-page__header-tools {
-    grid-column: -1 / 2;
+    grid-column: 3 !important;
+    grid-row: 1;
   }
-  
-  @media screen and (min-width: 375px) {
-    .app-context-selector-wrapper {
-      grid-column: 2 / 3;
-      grid-row: 1 / 2;
-    }
-  
-    .pf-c-context-selector {
-      width: initial;
-    }
-  
-    .pf-c-context-selector__toggle {
-      width: initial;
-      background-color: transparent;
-    }
-  
-    .pf-c-page__header-tools {
-      grid-column: -1 / 3;
-    }
+}
+
+@media screen and (max-width: 576px) {
+  .pf-c-context-selector__toggle::before {
+    border: initial;
   }
-  
-  @media screen and (max-width: 375px) {
-    .pf-c-context-selector__toggle::before {
-      border: initial;
-    }
+
+  .pf-c-context-selector {
+    width: 100% !important;
   }
-  
+
+  .app-context-selector-wrapper {
+    height: 76px;
+  }
+
+  .pf-c-context-selector__toggle {
+    background-color: transparent;
+  }
+
+  .pf-c-page__header-tools {
+    display: flex;
+    justify-content: flex-end;
+    height: 100%;
+    border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--200);
+    margin-top: 0 !important;
+    margin-right: 0 !important;
+    margin-bottom: 0 !important;
+    margin-left: 0 !important;
+    padding-top: var(--pf-global--spacer--sm);
+    padding-right: var(--pf-global--spacer--sm);
+    padding-bottom: var(--pf-global--spacer--sm);
+  }
+}


### PR DESCRIPTION
Clean up the cross-console nav styles as per the latest marvel designs: https://marvelapp.com/4aj7ig8/screen/68000571

<img width="499" alt="Screen Shot 2020-04-21 at 11 35 39 AM" src="https://user-images.githubusercontent.com/20118816/79892748-fb410500-83d0-11ea-9db4-7e44ac47f108.png">

<img width="850" alt="Screen Shot 2020-04-21 at 11 35 33 AM" src="https://user-images.githubusercontent.com/20118816/79892747-fa0fd800-83d0-11ea-9b48-88b26788bf34.png">
<img width="1028" alt="Screen Shot 2020-04-21 at 11 35 25 AM" src="https://user-images.githubusercontent.com/20118816/79892737-f8461480-83d0-11ea-96fe-03eecde4d837.png">

@dlabaj i would prefer to avoid a lot of the `!important` statements I had to make, are you able to change how the files are imported so that whatever is in this file overrides any of the PatternFly styles?

