### PR TITLE
Add conditional for when page header doesn't have cross-console

### DIFF
--- a/packages/demo-app/src/App.tsx
+++ b/packages/demo-app/src/App.tsx
@@ -192,7 +192,6 @@ export class App extends React.Component<{}, {
           toolbar={PageToolbar}
           avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
           showNavToggle
-          className="pf-m-no-crossconsole"
         />
       );
       const Sidebar = <PageSidebar nav={PageNav} theme="dark" />;

--- a/packages/demo-app/src/App.tsx
+++ b/packages/demo-app/src/App.tsx
@@ -192,6 +192,7 @@ export class App extends React.Component<{}, {
           toolbar={PageToolbar}
           avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
           showNavToggle
+          className="pf-m-no-crossconsole"
         />
       );
       const Sidebar = <PageSidebar nav={PageNav} theme="dark" />;

--- a/packages/integration-core/styles/core.css
+++ b/packages/integration-core/styles/core.css
@@ -177,6 +177,18 @@ img.pf-c-brand {
   .pf-c-page__header-brand-toggle {
     height: 76px;
   }
+
+  .pf-c-page__header.pf-m-no-crossconsole {
+    grid-template-rows: minmax(76px, auto);
+  }
+
+  .pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-tools {
+    grid-row: 1;
+  }
+
+  .pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-brand-toggle {
+    grid-row: 1;
+  }
 }
 
 .app__loading-container {

--- a/packages/integration-core/styles/core.css
+++ b/packages/integration-core/styles/core.css
@@ -15,6 +15,20 @@
   padding-right: var(--pf-global--spacer--md);
 }
 
+.pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-tools {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+.pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-brand-toggle {
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-brand-link {
+  grid-row: 1;
+  grid-column: 2;
+}
 
 .pf-c-page__header {
   grid-template-columns: auto auto auto !important;
@@ -76,7 +90,7 @@ img.pf-c-brand {
 }
 
 .pf-c-page__header-brand-link {
-  grid-column: 1 / span 2;
+  grid-column: 1;
   grid-row: 1;
 }
 
@@ -155,11 +169,6 @@ img.pf-c-brand {
     background-color: transparent;
   }
 
-  .pf-c-page__header-brand-link {
-    padding-left: var(--pf-global--spacer--md);
-    padding-right: var(--pf-global--spacer--md);
-  }
-
   .pf-c-page__header-tools {
     display: flex;
     justify-content: flex-end;
@@ -182,12 +191,8 @@ img.pf-c-brand {
     grid-template-rows: minmax(76px, auto);
   }
 
-  .pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-tools {
-    grid-row: 1;
-  }
-
-  .pf-c-page__header.pf-m-no-crossconsole .pf-c-page__header-brand-toggle {
-    grid-row: 1;
+  .pf-c-page__header.pf-m-no-crossconsole.pf-m-no-toggle .pf-c-page__header-brand-link {
+    grid-column: 1;
   }
 }
 

--- a/packages/integration-react/src/components/CrossNavHeader/CrossNavHeader.tsx
+++ b/packages/integration-react/src/components/CrossNavHeader/CrossNavHeader.tsx
@@ -95,9 +95,10 @@ export class CrossNavHeader extends React.Component<CrossNavHeaderProps, CrossNa
         {({ isManagedSidebar, onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }: PageHeaderProps) => {
           const navToggle = isManagedSidebar ? managedOnNavToggle : onNavToggle;
           const navOpen = isManagedSidebar ? managedIsNavOpen : isNavOpen;
+          const isCrossConsole = apps && apps.length > 0 && true;
 
           return (
-            <header role="banner" className={`${css(styles.pageHeader, className)} ${!showNavToggle ? 'pf-m-no-toggle' : ''} `} {...props}>
+            <header role="banner" className={`${css(styles.pageHeader, className)} ${!showNavToggle ? 'pf-m-no-toggle' : ''} ${!isCrossConsole && `pf-m-no-crossconsole`} `} {...props}>
               {showNavToggle && (
                 <div className={css(styles.pageHeaderBrandToggle)}>
                   <Button
@@ -117,7 +118,7 @@ export class CrossNavHeader extends React.Component<CrossNavHeaderProps, CrossNa
                   {logo}
                 </LogoComponent>
               )}
-              {apps && apps.length > 0 ? <CrossNavContextSelector 
+              {isCrossConsole ? <CrossNavContextSelector 
                   toggleText = {currentApp.name} 
                   onToggle={this.onToggle}
                   onSelect={this.onSelect}


### PR DESCRIPTION
`pf-m-no-toggle pf-m-no-crossconsole`

<img width="834" alt="Screen Shot 2020-06-11 at 10 39 58 AM" src="https://user-images.githubusercontent.com/20118816/84402466-75705780-abd2-11ea-80cf-e51677e123db.png">
<img width="457" alt="Screen Shot 2020-06-11 at 10 40 07 AM" src="https://user-images.githubusercontent.com/20118816/84402472-7608ee00-abd2-11ea-8cb3-b51c5dd3ab94.png">

`pf-m-no-crossconsole`
<img width="939" alt="Screen Shot 2020-06-11 at 10 48 18 AM" src="https://user-images.githubusercontent.com/20118816/84402562-93d65300-abd2-11ea-8813-8e0220dabf1d.png">
<img width="478" alt="Screen Shot 2020-06-11 at 10 48 26 AM" src="https://user-images.githubusercontent.com/20118816/84402565-95078000-abd2-11ea-82dc-4e1402044911.png">


